### PR TITLE
[DEV] 설정 페이지 ui 작업

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,11 +1,12 @@
 declare module "*.svg" {
-    import React = require("react");
-    export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
-    const src: string;
-    export default src;
+    import type { FC, SVGProps } from "react";
+
+    export const ReactComponent: FC<SVGProps<SVGSVGElement>>;
+    const Component: FC<SVGProps<SVGSVGElement>>;
+    export default Component;
 }
 
 declare module "*.svg?url" {
-    const content: any;
+    const content: string;
     export default content;
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
+type WebpackConfig = Parameters<NonNullable<NextConfig["webpack"]>>[0];
+type SvgRule = {
+  test?: { test?: (value: string) => boolean };
+  issuer?: unknown;
+  resourceQuery?: { not?: RegExp[] } | RegExp;
+  exclude?: RegExp;
+};
+
 const nextConfig: NextConfig = {
   turbopack: {
+    root: process.cwd(),
     rules: {
       "*.svg": {
         loaders: ["@svgr/webpack"],
@@ -9,9 +18,12 @@ const nextConfig: NextConfig = {
       },
     },
   },
-  webpack(config) {
-    const fileLoaderRule = config.module.rules.find((rule: any) =>
-      rule.test?.test?.(".svg")
+  webpack(config: WebpackConfig) {
+    const fileLoaderRule = config.module.rules.find((rule: unknown): rule is SvgRule =>
+      typeof rule === "object" &&
+      rule !== null &&
+      "test" in rule &&
+      Boolean((rule as SvgRule).test?.test?.(".svg"))
     );
 
     config.module.rules.push(

--- a/src/app/(protected)/reports/[id]/page.tsx
+++ b/src/app/(protected)/reports/[id]/page.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 interface ReportDetailPageProps {
     params: Promise<{ id: string }>
 }

--- a/src/app/(protected)/settings/_components/ActionRow.tsx
+++ b/src/app/(protected)/settings/_components/ActionRow.tsx
@@ -1,0 +1,24 @@
+interface ActionRowProps {
+    label: string
+    buttonLabel: string
+    danger?: boolean
+}
+
+export default function ActionRow({ label, buttonLabel, danger = false }: ActionRowProps) {
+    return (
+        <div className="flex w-full items-center justify-between gap-4">
+            <p className="min-w-0 truncate font-body-14m text-text-primary desktop:font-body-16m">
+                {label}
+            </p>
+            <button
+                type="button"
+                className={`shrink-0 rounded-[20px] border px-3 py-1.5 font-body-14m transition-colors desktop:font-body-16m ${danger
+                    ? 'border-border-error text-border-error hover:bg-border-error/10'
+                    : 'border-border-default text-text-primary hover:bg-bg-1'
+                    }`}
+            >
+                {buttonLabel}
+            </button>
+        </div>
+    )
+}

--- a/src/app/(protected)/settings/_components/EditableTextField.tsx
+++ b/src/app/(protected)/settings/_components/EditableTextField.tsx
@@ -5,12 +5,10 @@ import TextField, { type TextFieldProps } from '@/components/TextField'
 
 interface EditableTextFieldProps extends Omit<TextFieldProps, 'value' | 'onChange'> {
     initialValue?: string
-    activeInputClassName?: string
 }
 
 export default function EditableTextField({
     initialValue = '',
-    activeInputClassName = '',
     inputClassName = '',
     onFocus,
     ...props
@@ -53,7 +51,7 @@ export default function EditableTextField({
                     setIsEditing(true)
                     onFocus?.(event)
                 }}
-                inputClassName={`${inputClassName} ${isEditing ? activeInputClassName : ''}`.trim()}
+                inputClassName={inputClassName}
             />
 
             <div className={`${isEditing ? 'flex' : 'hidden'} gap-1 pb-2 group-focus-within/editable:flex`}>

--- a/src/app/(protected)/settings/_components/EditableTextField.tsx
+++ b/src/app/(protected)/settings/_components/EditableTextField.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { type MouseEvent, useRef, useState } from 'react'
+import TextField, { type TextFieldProps } from '@/components/TextField'
+
+interface EditableTextFieldProps extends Omit<TextFieldProps, 'value' | 'onChange'> {
+    initialValue?: string
+    activeInputClassName?: string
+}
+
+export default function EditableTextField({
+    initialValue = '',
+    activeInputClassName = '',
+    inputClassName = '',
+    onFocus,
+    ...props
+}: EditableTextFieldProps) {
+    const fieldRef = useRef<HTMLDivElement>(null)
+    const [savedValue, setSavedValue] = useState(initialValue)
+    const [draftValue, setDraftValue] = useState(initialValue)
+    const [isEditing, setIsEditing] = useState(false)
+
+    function closeEditor() {
+        const activeElement = document.activeElement
+
+        if (activeElement instanceof HTMLElement && fieldRef.current?.contains(activeElement)) {
+            activeElement.blur()
+        }
+
+        setIsEditing(false)
+    }
+
+    function handleCancel(event: MouseEvent<HTMLButtonElement>) {
+        event.currentTarget.blur()
+        setDraftValue(savedValue)
+        closeEditor()
+    }
+
+    function handleSave(event: MouseEvent<HTMLButtonElement>) {
+        event.currentTarget.blur()
+        setSavedValue(draftValue)
+        closeEditor()
+    }
+
+    return (
+        <div ref={fieldRef} className="group/editable flex w-full flex-col items-end gap-2">
+            <TextField
+                {...props}
+                isActive={isEditing}
+                value={draftValue}
+                onChange={setDraftValue}
+                onFocus={(event) => {
+                    setIsEditing(true)
+                    onFocus?.(event)
+                }}
+                inputClassName={`${inputClassName} ${isEditing ? activeInputClassName : ''}`.trim()}
+            />
+
+            <div className={`${isEditing ? 'flex' : 'hidden'} gap-1 pb-2 group-focus-within/editable:flex`}>
+                <button
+                    type="button"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={handleCancel}
+                    className="rounded-[20px] bg-bg-1 px-3 py-1.5 font-caption-12m text-text-primary transition-colors hover:bg-bg-2"
+                >
+                    취소
+                </button>
+                <button
+                    type="button"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={handleSave}
+                    className="rounded-[20px] bg-primary-60 px-3 py-1.5 font-caption-12m text-text-primary transition-colors hover:bg-primary-70"
+                >
+                    저장
+                </button>
+            </div>
+        </div>
+    )
+}

--- a/src/app/(protected)/settings/_components/NotificationRow.tsx
+++ b/src/app/(protected)/settings/_components/NotificationRow.tsx
@@ -1,24 +1,22 @@
 'use client'
 
-import { useState } from 'react'
 import Toggle from './Toggle'
 
 interface NotificationRowProps {
-    title: string
+    checked: boolean
     description: string
-    defaultChecked?: boolean
+    onChange: (checked: boolean) => void
+    title: string
 }
 
-export default function NotificationRow({ title, description, defaultChecked = false }: NotificationRowProps) {
-    const [checked, setChecked] = useState(defaultChecked)
-
+export default function NotificationRow({ checked, description, onChange, title }: NotificationRowProps) {
     return (
         <div className="flex w-full flex-col gap-1">
             <div className="flex w-full items-center justify-between gap-4">
                 <h2 className="min-w-0 truncate font-body-16sb text-text-primary desktop:text-[18px] desktop:leading-[1.5]">
                     {title}
                 </h2>
-                <Toggle checked={checked} label={title} onChange={setChecked} />
+                <Toggle checked={checked} label={title} onChange={onChange} />
             </div>
             <p className="truncate font-caption-12r text-text-secondary desktop:font-body-14r">
                 {description}

--- a/src/app/(protected)/settings/_components/NotificationRow.tsx
+++ b/src/app/(protected)/settings/_components/NotificationRow.tsx
@@ -1,0 +1,23 @@
+import Toggle from './Toggle'
+
+interface NotificationRowProps {
+    title: string
+    description: string
+    checked?: boolean
+}
+
+export default function NotificationRow({ title, description, checked = false }: NotificationRowProps) {
+    return (
+        <div className="flex w-full flex-col gap-1">
+            <div className="flex w-full items-center justify-between gap-4">
+                <h2 className="min-w-0 truncate font-body-16sb text-text-primary desktop:text-[18px] desktop:leading-[1.5]">
+                    {title}
+                </h2>
+                <Toggle checked={checked} label={title} />
+            </div>
+            <p className="truncate font-caption-12r text-text-secondary desktop:font-body-14r">
+                {description}
+            </p>
+        </div>
+    )
+}

--- a/src/app/(protected)/settings/_components/NotificationRow.tsx
+++ b/src/app/(protected)/settings/_components/NotificationRow.tsx
@@ -1,19 +1,24 @@
+'use client'
+
+import { useState } from 'react'
 import Toggle from './Toggle'
 
 interface NotificationRowProps {
     title: string
     description: string
-    checked?: boolean
+    defaultChecked?: boolean
 }
 
-export default function NotificationRow({ title, description, checked = false }: NotificationRowProps) {
+export default function NotificationRow({ title, description, defaultChecked = false }: NotificationRowProps) {
+    const [checked, setChecked] = useState(defaultChecked)
+
     return (
         <div className="flex w-full flex-col gap-1">
             <div className="flex w-full items-center justify-between gap-4">
                 <h2 className="min-w-0 truncate font-body-16sb text-text-primary desktop:text-[18px] desktop:leading-[1.5]">
                     {title}
                 </h2>
-                <Toggle checked={checked} label={title} />
+                <Toggle checked={checked} label={title} onChange={setChecked} />
             </div>
             <p className="truncate font-caption-12r text-text-secondary desktop:font-body-14r">
                 {description}

--- a/src/app/(protected)/settings/_components/ProfileField.tsx
+++ b/src/app/(protected)/settings/_components/ProfileField.tsx
@@ -1,0 +1,17 @@
+interface ProfileFieldProps {
+    label: string
+    value: string
+}
+
+export default function ProfileField({ label, value }: ProfileFieldProps) {
+    return (
+        <div className="flex w-full flex-col gap-0.5">
+            <span className="font-caption-12m text-text-secondary desktop:font-body-14m">
+                {label}
+            </span>
+            <span className="truncate font-body-16sb text-text-primary desktop:text-[18px] desktop:leading-[1.5]">
+                {value}
+            </span>
+        </div>
+    )
+}

--- a/src/app/(protected)/settings/_components/SectionDivider.tsx
+++ b/src/app/(protected)/settings/_components/SectionDivider.tsx
@@ -1,3 +1,3 @@
 export default function SectionDivider() {
-    return <div className="h-4 w-full shrink-0 bg-[#020202]" />
+    return <div className="h-4 w-full shrink-0 bg-bg-divider" />
 }

--- a/src/app/(protected)/settings/_components/SectionDivider.tsx
+++ b/src/app/(protected)/settings/_components/SectionDivider.tsx
@@ -1,0 +1,3 @@
+export default function SectionDivider() {
+    return <div className="h-4 w-full shrink-0 bg-[#020202]" />
+}

--- a/src/app/(protected)/settings/_components/SettingHeader.tsx
+++ b/src/app/(protected)/settings/_components/SettingHeader.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import MenuIcon from '@/assets/icons/menu.svg'
+import { useLayoutStore } from '@/stores/layoutStore'
+
+export default function SettingHeader() {
+    const openSidebar = useLayoutStore((state) => state.openSidebar)
+
+    return (
+        <header className="shrink-0 bg-bg-0 px-4 py-3 tablet:px-5 tablet:py-4 desktop:px-16 desktop:py-5">
+            <div className="flex h-8 items-center gap-2">
+                <button
+                    type="button"
+                    onClick={openSidebar}
+                    className="-ml-1 flex size-8 items-center justify-center text-icon-primary transition-colors hover:text-text-primary desktop:hidden"
+                    aria-label="메뉴 열기"
+                >
+                    <MenuIcon />
+                </button>
+                <h1 className="font-title-18sb text-text-primary desktop:font-title-20sb">
+                    설정
+                </h1>
+            </div>
+        </header>
+    )
+}

--- a/src/app/(protected)/settings/_components/SettingsProfileImage.tsx
+++ b/src/app/(protected)/settings/_components/SettingsProfileImage.tsx
@@ -1,0 +1,17 @@
+import ProfileImage from '@/components/ProfileImage'
+
+interface SettingsProfileImageProps {
+    channelName: string
+}
+
+export default function SettingsProfileImage({ channelName }: SettingsProfileImageProps) {
+    const label = `${channelName} 프로필 이미지`
+
+    return (
+        <>
+            <ProfileImage size={80} aria-label={label} className="tablet:hidden" />
+            <ProfileImage size={120} aria-label={label} className="hidden tablet:block desktop:hidden" />
+            <ProfileImage size={193} aria-label={label} className="hidden desktop:block" />
+        </>
+    )
+}

--- a/src/app/(protected)/settings/_components/Toggle.tsx
+++ b/src/app/(protected)/settings/_components/Toggle.tsx
@@ -1,9 +1,10 @@
 interface ToggleProps {
     checked?: boolean
     label: string
+    onChange?: (checked: boolean) => void
 }
 
-export default function Toggle({ checked = false, label }: ToggleProps) {
+export default function Toggle({ checked = false, label, onChange }: ToggleProps) {
     const thumbPositionClass = checked ? 'left-[21.6px]' : 'left-[2.4px]'
 
     return (
@@ -11,6 +12,7 @@ export default function Toggle({ checked = false, label }: ToggleProps) {
             type="button"
             aria-pressed={checked}
             aria-label={label}
+            onClick={() => onChange?.(!checked)}
             className={`relative h-6 w-[43.2px] shrink-0 rounded-3xl transition-colors ${checked ? 'bg-primary-60' : 'bg-bg-2'}`}
         >
             <span

--- a/src/app/(protected)/settings/_components/Toggle.tsx
+++ b/src/app/(protected)/settings/_components/Toggle.tsx
@@ -1,0 +1,21 @@
+interface ToggleProps {
+    checked?: boolean
+    label: string
+}
+
+export default function Toggle({ checked = false, label }: ToggleProps) {
+    const thumbPositionClass = checked ? 'left-[21.6px]' : 'left-[2.4px]'
+
+    return (
+        <button
+            type="button"
+            aria-pressed={checked}
+            aria-label={label}
+            className={`relative h-6 w-[43.2px] shrink-0 rounded-3xl transition-colors ${checked ? 'bg-primary-60' : 'bg-bg-2'}`}
+        >
+            <span
+                className={`absolute top-[2.4px] size-[19.2px] rounded-full bg-gray-95 transition-[left] ${thumbPositionClass}`}
+            />
+        </button>
+    )
+}

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useState } from 'react'
 import MenuIcon from '@/assets/icons/menu.svg'
 import ProfileImage from '@/components/ProfileImage'
+import TextField from '@/components/TextField'
 import { useLayoutStore } from '@/stores/layoutStore'
 
 const channel = {
@@ -60,50 +60,6 @@ function SettingsProfileImage() {
             <ProfileImage size={120} aria-label={label} className="hidden tablet:block desktop:hidden" />
             <ProfileImage size={193} aria-label={label} className="hidden desktop:block" />
         </>
-    )
-}
-
-interface SettingTextAreaProps {
-    label: string
-    maxLength: number
-    placeholder: string
-    rows?: 'short' | 'large'
-}
-
-function SettingTextArea({ label, maxLength, placeholder, rows = 'short' }: SettingTextAreaProps) {
-    const [value, setValue] = useState('')
-    const heightClass = rows === 'large'
-        ? 'h-[151px]'
-        : 'min-h-[88px] desktop:min-h-[100px]'
-
-    return (
-        <label className={`flex w-full max-w-[calc(100vw-32px)] cursor-text flex-col gap-1 rounded-[20px] bg-bg-1 px-4 py-3 tablet:max-w-none ${heightClass}`}>
-            <span className="flex w-full items-start justify-between gap-4 font-caption-12m text-text-secondary desktop:font-body-14m">
-                <span className="truncate">{label}</span>
-                <span className="flex shrink-0 items-center font-caption-12r text-text-tertiary desktop:font-body-14r">
-                    <span className="font-caption-12m text-text-secondary desktop:font-body-14m">0</span>
-                    <span>/</span>
-                    <span>{maxLength}</span>
-                </span>
-            </span>
-            <span className="relative min-h-0 w-full flex-1 overflow-hidden">
-                {value.length === 0 && (
-                    <span
-                        className="pointer-events-none absolute inset-0 block w-full max-w-[calc(100vw-64px)] whitespace-normal font-body-14r text-text-secondary tablet:max-w-none desktop:font-body-16r"
-                        style={{ wordBreak: 'break-all', overflowWrap: 'anywhere' }}
-                    >
-                        {placeholder}
-                    </span>
-                )}
-                <textarea
-                    className="absolute inset-0 size-full resize-none bg-transparent p-0 font-body-14r text-text-primary outline-none desktop:font-body-16r"
-                    value={value}
-                    onChange={(event) => setValue(event.target.value)}
-                    maxLength={maxLength}
-                    aria-label={label}
-                />
-            </span>
-        </label>
     )
 }
 
@@ -194,16 +150,23 @@ export default function SettingsPage() {
                         </div>
 
                         <div className="flex w-full flex-col gap-2">
-                            <SettingTextArea
+                            <TextField
                                 label="채널 타겟층"
                                 maxLength={50}
                                 placeholder="더욱 최적화된 분석 및 제안을 위해 채널 타겟층을 입력해주세요"
+                                fullWidth
+                                inputClassName="h-[88px] desktop:h-[100px]"
+                                labelClassName="desktop:font-body-14m"
+                                textareaClassName="desktop:font-body-16r"
                             />
-                            <SettingTextArea
+                            <TextField
                                 label="채널 컨셉"
                                 maxLength={150}
                                 placeholder="더욱 최적화된 분석 및 제안을 위해 채널 컨셉을 입력해주세요"
-                                rows="large"
+                                heightVariant="large"
+                                fullWidth
+                                labelClassName="desktop:font-body-14m"
+                                textareaClassName="desktop:font-body-16r"
                             />
                         </div>
                     </div>

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -1,118 +1,15 @@
-'use client'
-
-import MenuIcon from '@/assets/icons/menu.svg'
-import ProfileImage from '@/components/ProfileImage'
 import TextField from '@/components/TextField'
-import { useLayoutStore } from '@/stores/layoutStore'
-import Toggle from './_components/Toggle'
+import ActionRow from './_components/ActionRow'
+import NotificationRow from './_components/NotificationRow'
+import ProfileField from './_components/ProfileField'
+import SectionDivider from './_components/SectionDivider'
+import SettingHeader from './_components/SettingHeader'
+import SettingsProfileImage from './_components/SettingsProfileImage'
 
 const channel = {
     name: 'LeoJ Makeup',
     email: 'LeoJMakeup@gmail.com',
     loginId: 'kjh21351324390',
-}
-
-function SettingHeader() {
-    const openSidebar = useLayoutStore((state) => state.openSidebar)
-
-    return (
-        <header className="shrink-0 bg-bg-0 px-4 py-3 tablet:px-5 tablet:py-4 desktop:px-16 desktop:py-5">
-            <div className="flex h-8 items-center gap-2">
-                <button
-                    type="button"
-                    onClick={openSidebar}
-                    className="-ml-1 flex size-8 items-center justify-center text-icon-primary transition-colors hover:text-text-primary desktop:hidden"
-                    aria-label="메뉴 열기"
-                >
-                    <MenuIcon />
-                </button>
-                <h1 className="font-title-18sb text-text-primary desktop:font-title-20sb">
-                    설정
-                </h1>
-            </div>
-        </header>
-    )
-}
-
-interface ProfileFieldProps {
-    label: string
-    value: string
-}
-
-function ProfileField({ label, value }: ProfileFieldProps) {
-    return (
-        <div className="flex w-full flex-col gap-0.5">
-            <span className="font-caption-12m text-text-secondary desktop:font-body-14m">
-                {label}
-            </span>
-            <span className="truncate font-body-16sb text-text-primary desktop:text-[18px] desktop:leading-[1.5]">
-                {value}
-            </span>
-        </div>
-    )
-}
-
-function SettingsProfileImage() {
-    const label = `${channel.name} 프로필 이미지`
-
-    return (
-        <>
-            <ProfileImage size={80} aria-label={label} className="tablet:hidden" />
-            <ProfileImage size={120} aria-label={label} className="hidden tablet:block desktop:hidden" />
-            <ProfileImage size={193} aria-label={label} className="hidden desktop:block" />
-        </>
-    )
-}
-
-interface NotificationRowProps {
-    title: string
-    description: string
-    checked?: boolean
-}
-
-function NotificationRow({ title, description, checked = false }: NotificationRowProps) {
-    return (
-        <div className="flex w-full flex-col gap-1">
-            <div className="flex w-full items-center justify-between gap-4">
-                <h2 className="min-w-0 truncate font-body-16sb text-text-primary desktop:text-[18px] desktop:leading-[1.5]">
-                    {title}
-                </h2>
-                <Toggle checked={checked} label={title} />
-            </div>
-            <p className="truncate font-caption-12r text-text-secondary desktop:font-body-14r">
-                {description}
-            </p>
-        </div>
-    )
-}
-
-interface ActionRowProps {
-    label: string
-    buttonLabel: string
-    danger?: boolean
-}
-
-function ActionRow({ label, buttonLabel, danger = false }: ActionRowProps) {
-    return (
-        <div className="flex w-full items-center justify-between gap-4">
-            <p className="min-w-0 truncate font-body-14m text-text-primary desktop:font-body-16m">
-                {label}
-            </p>
-            <button
-                type="button"
-                className={`shrink-0 rounded-[20px] border px-3 py-1.5 font-body-14m transition-colors desktop:font-body-16m ${danger
-                    ? 'border-border-error text-border-error hover:bg-border-error/10'
-                    : 'border-border-default text-text-primary hover:bg-bg-1'
-                    }`}
-            >
-                {buttonLabel}
-            </button>
-        </div>
-    )
-}
-
-function SectionDivider() {
-    return <div className="h-4 w-full shrink-0 bg-[#020202]" />
 }
 
 export default function SettingsPage() {
@@ -123,7 +20,7 @@ export default function SettingsPage() {
             <main className="flex-1 overflow-y-auto custom-scrollbar">
                 <section className="flex flex-col gap-8 pb-8">
                     <div className="flex w-full flex-col gap-[22px] px-4 pt-[17px] tablet:px-5 desktop:px-16 desktop:pt-0">
-                        <SettingsProfileImage />
+                        <SettingsProfileImage channelName={channel.name} />
 
                         <div className="flex w-full flex-col gap-2">
                             <ProfileField label="채널명" value={channel.name} />

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -4,6 +4,7 @@ import MenuIcon from '@/assets/icons/menu.svg'
 import ProfileImage from '@/components/ProfileImage'
 import TextField from '@/components/TextField'
 import { useLayoutStore } from '@/stores/layoutStore'
+import Toggle from './_components/Toggle'
 
 const channel = {
     name: 'LeoJ Makeup',
@@ -60,28 +61,6 @@ function SettingsProfileImage() {
             <ProfileImage size={120} aria-label={label} className="hidden tablet:block desktop:hidden" />
             <ProfileImage size={193} aria-label={label} className="hidden desktop:block" />
         </>
-    )
-}
-
-interface ToggleProps {
-    checked?: boolean
-    label: string
-}
-
-function Toggle({ checked = false, label }: ToggleProps) {
-    const thumbPositionClass = checked ? 'left-[21.6px]' : 'left-[2.4px]'
-
-    return (
-        <button
-            type="button"
-            aria-pressed={checked}
-            aria-label={label}
-            className={`relative h-6 w-[43.2px] shrink-0 rounded-3xl transition-colors ${checked ? 'bg-primary-60' : 'bg-bg-2'}`}
-        >
-            <span
-                className={`absolute top-[2.4px] size-[19.2px] rounded-full bg-gray-95 transition-[left] ${thumbPositionClass}`}
-            />
-        </button>
     )
 }
 

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -107,27 +107,6 @@ function NotificationRow({ title, description, checked = false }: NotificationRo
     )
 }
 
-function EmailNotificationSection() {
-    return (
-        <div className="flex w-full flex-col gap-2 px-4 tablet:px-5 desktop:px-16">
-            <p className="font-caption-12m text-text-secondary desktop:font-body-14m">
-                이메일 알림
-            </p>
-            <div className="flex w-full flex-col gap-4">
-                <NotificationRow
-                    title="마케팅 이메일 수신 동의"
-                    description="이벤트 또는 혜택과 관련된 마케팅 이메일 수신을 받아요"
-                    checked
-                />
-                <NotificationRow
-                    title="일일 콘텐츠 추천 메일 수신"
-                    description="프리미엄 요금제에서 제공되는 일일 콘텐츠를 추천 받아요"
-                />
-            </div>
-        </div>
-    )
-}
-
 interface ActionRowProps {
     label: string
     buttonLabel: string
@@ -196,7 +175,22 @@ export default function SettingsPage() {
 
                     <SectionDivider />
 
-                    <EmailNotificationSection />
+                    <div className="flex w-full flex-col gap-2 px-4 tablet:px-5 desktop:px-16">
+                        <p className="font-caption-12m text-text-secondary desktop:font-body-14m">
+                            이메일 알림
+                        </p>
+                        <div className="flex w-full flex-col gap-4">
+                            <NotificationRow
+                                title="마케팅 이메일 수신 동의"
+                                description="이벤트 또는 혜택과 관련된 마케팅 이메일 수신을 받아요"
+                                checked
+                            />
+                            <NotificationRow
+                                title="일일 콘텐츠 추천 메일 수신"
+                                description="프리미엄 요금제에서 제공되는 일일 콘텐츠를 추천 받아요"
+                            />
+                        </div>
+                    </div>
 
                     <SectionDivider />
 

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -1,17 +1,245 @@
 'use client'
 
-/**
- * 설정 페이지 (/settings)
- * - 개인정보 수정
- * - 서비스 설정
- */
+import { useState } from 'react'
+import MenuIcon from '@/assets/icons/menu.svg'
+import { useLayoutStore } from '@/stores/layoutStore'
+
+const channel = {
+    name: 'LeoJ Makeup',
+    email: 'LeoJMakeup@gmail.com',
+    loginId: 'kjh21351324390',
+}
+
+function SettingHeader() {
+    const openSidebar = useLayoutStore((state) => state.openSidebar)
+
+    return (
+        <header className="shrink-0 bg-bg-0 px-4 py-3 tablet:px-5 tablet:py-4 desktop:px-16 desktop:py-5">
+            <div className="flex h-8 items-center gap-2">
+                <button
+                    type="button"
+                    onClick={openSidebar}
+                    className="-ml-1 flex size-8 items-center justify-center text-icon-primary transition-colors hover:text-text-primary desktop:hidden"
+                    aria-label="메뉴 열기"
+                >
+                    <MenuIcon />
+                </button>
+                <h1 className="font-title-18sb text-text-primary desktop:font-title-20sb">
+                    설정
+                </h1>
+            </div>
+        </header>
+    )
+}
+
+interface ProfileFieldProps {
+    label: string
+    value: string
+}
+
+function ProfileField({ label, value }: ProfileFieldProps) {
+    return (
+        <div className="flex w-full flex-col gap-0.5">
+            <span className="font-caption-12m text-text-secondary desktop:font-body-14m">
+                {label}
+            </span>
+            <span className="truncate font-body-16sb text-text-primary desktop:text-[18px] desktop:leading-[1.5]">
+                {value}
+            </span>
+        </div>
+    )
+}
+
+function ProfileAvatar() {
+    return (
+        <div
+            className="flex size-20 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary-40 text-[20px] font-semibold leading-none text-text-primary tablet:size-[120px] tablet:text-[28px] desktop:size-[193px] desktop:text-[44px]"
+            aria-label={`${channel.name} 프로필 이미지`}
+        >
+            LJ
+        </div>
+    )
+}
+
+interface SettingTextAreaProps {
+    label: string
+    maxLength: number
+    placeholder: string
+    rows?: 'short' | 'large'
+}
+
+function SettingTextArea({ label, maxLength, placeholder, rows = 'short' }: SettingTextAreaProps) {
+    const [value, setValue] = useState('')
+    const heightClass = rows === 'large'
+        ? 'h-[151px]'
+        : 'min-h-[88px] desktop:min-h-[100px]'
+
+    return (
+        <label className={`flex w-full max-w-[calc(100vw-32px)] cursor-text flex-col gap-1 rounded-[20px] bg-bg-1 px-4 py-3 tablet:max-w-none ${heightClass}`}>
+            <span className="flex w-full items-start justify-between gap-4 font-caption-12m text-text-secondary desktop:font-body-14m">
+                <span className="truncate">{label}</span>
+                <span className="flex shrink-0 items-center font-caption-12r text-text-tertiary desktop:font-body-14r">
+                    <span className="font-caption-12m text-text-secondary desktop:font-body-14m">0</span>
+                    <span>/</span>
+                    <span>{maxLength}</span>
+                </span>
+            </span>
+            <span className="relative min-h-0 w-full flex-1 overflow-hidden">
+                {value.length === 0 && (
+                    <span
+                        className="pointer-events-none absolute inset-0 block w-full max-w-[calc(100vw-64px)] whitespace-normal font-body-14r text-text-secondary tablet:max-w-none desktop:font-body-16r"
+                        style={{ wordBreak: 'break-all', overflowWrap: 'anywhere' }}
+                    >
+                        {placeholder}
+                    </span>
+                )}
+                <textarea
+                    className="absolute inset-0 size-full resize-none bg-transparent p-0 font-body-14r text-text-primary outline-none desktop:font-body-16r"
+                    value={value}
+                    onChange={(event) => setValue(event.target.value)}
+                    maxLength={maxLength}
+                    aria-label={label}
+                />
+            </span>
+        </label>
+    )
+}
+
+interface ToggleProps {
+    checked?: boolean
+    label: string
+}
+
+function Toggle({ checked = false, label }: ToggleProps) {
+    return (
+        <button
+            type="button"
+            aria-pressed={checked}
+            aria-label={label}
+            className={`relative h-6 w-[43.2px] shrink-0 rounded-3xl transition-colors ${checked ? 'bg-primary-60' : 'bg-bg-2'}`}
+        >
+            <span
+                className={`absolute top-[2.4px] size-[19.2px] rounded-full bg-gray-95 transition-transform ${checked ? 'translate-x-[21.6px]' : 'translate-x-[2.4px]'}`}
+            />
+        </button>
+    )
+}
+
+interface NotificationRowProps {
+    title: string
+    description: string
+    checked?: boolean
+}
+
+function NotificationRow({ title, description, checked = false }: NotificationRowProps) {
+    return (
+        <div className="flex w-full flex-col gap-1">
+            <div className="flex w-full items-center justify-between gap-4">
+                <h2 className="min-w-0 truncate font-body-16sb text-text-primary desktop:text-[18px] desktop:leading-[1.5]">
+                    {title}
+                </h2>
+                <Toggle checked={checked} label={title} />
+            </div>
+            <p className="truncate font-caption-12r text-text-secondary desktop:font-body-14r">
+                {description}
+            </p>
+        </div>
+    )
+}
+
+interface ActionRowProps {
+    label: string
+    buttonLabel: string
+    danger?: boolean
+}
+
+function ActionRow({ label, buttonLabel, danger = false }: ActionRowProps) {
+    return (
+        <div className="flex w-full items-center justify-between gap-4">
+            <p className="min-w-0 truncate font-body-14m text-text-primary desktop:font-body-16m">
+                {label}
+            </p>
+            <button
+                type="button"
+                className={`shrink-0 rounded-[20px] border px-3 py-1.5 font-body-14m transition-colors desktop:font-body-16m ${danger
+                    ? 'border-border-error text-border-error hover:bg-border-error/10'
+                    : 'border-border-default text-text-primary hover:bg-bg-1'
+                    }`}
+            >
+                {buttonLabel}
+            </button>
+        </div>
+    )
+}
+
+function SectionDivider() {
+    return <div className="h-4 w-full shrink-0 bg-[#020202]" />
+}
+
 export default function SettingsPage() {
     return (
-        <main className="p-6">
-            <h1 className="text-2xl font-bold">설정</h1>
+        <div className="flex h-full w-full flex-col bg-bg-0">
+            <SettingHeader />
 
-            {/* TODO: 개인정보 수정 섹션 */}
-            {/* TODO: 서비스 설정 섹션 */}
-        </main>
+            <main className="flex-1 overflow-y-auto custom-scrollbar">
+                <section className="flex flex-col gap-8 pb-8">
+                    <div className="flex w-full flex-col gap-[22px] px-4 pt-[17px] tablet:px-5 desktop:px-16 desktop:pt-0">
+                        <ProfileAvatar />
+
+                        <div className="flex w-full flex-col gap-2">
+                            <ProfileField label="채널명" value={channel.name} />
+                            <ProfileField label="이메일" value={channel.email} />
+                        </div>
+
+                        <div className="flex w-full flex-col gap-2">
+                            <SettingTextArea
+                                label="채널 타겟층"
+                                maxLength={50}
+                                placeholder="더욱 최적화된 분석 및 제안을 위해 채널 타겟층을 입력해주세요"
+                            />
+                            <SettingTextArea
+                                label="채널 컨셉"
+                                maxLength={150}
+                                placeholder="더욱 최적화된 분석 및 제안을 위해 채널 컨셉을 입력해주세요"
+                                rows="large"
+                            />
+                        </div>
+                    </div>
+
+                    <SectionDivider />
+
+                    <div className="flex w-full flex-col gap-2 px-4 tablet:px-5 desktop:px-16">
+                        <p className="font-caption-12m text-text-secondary desktop:font-body-14m">
+                            이메일 알림
+                        </p>
+                        <div className="flex w-full flex-col gap-4">
+                            <NotificationRow
+                                title="마케팅 이메일 수신 동의"
+                                description="이벤트 또는 혜택과 관련된 마케팅 이메일 수신을 받아요"
+                                checked
+                            />
+                            <NotificationRow
+                                title="일일 콘텐츠 추천 메일 수신"
+                                description="프리미엄 요금제에서 제공되는 일일 콘텐츠를 추천 받아요"
+                            />
+                        </div>
+                    </div>
+
+                    <SectionDivider />
+
+                    <div className="flex w-full flex-col gap-4 px-4 tablet:px-5 desktop:px-16">
+                        <ActionRow
+                            label={`${channel.loginId}로 로그인 되어 있습니다`}
+                            buttonLabel="로그아웃"
+                        />
+                        <ActionRow
+                            label="계정 삭제하기"
+                            buttonLabel="계정 삭제"
+                            danger
+                        />
+                    </div>
+                </section>
+            </main>
+        </div>
     )
 }

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -1,3 +1,4 @@
+import Scroll from '@/components/Scroll'
 import TextField from '@/components/TextField'
 import ActionRow from './_components/ActionRow'
 import NotificationRow from './_components/NotificationRow'
@@ -17,7 +18,7 @@ export default function SettingsPage() {
         <div className="flex h-full w-full flex-col bg-bg-0">
             <SettingHeader />
 
-            <main className="flex-1 overflow-y-auto custom-scrollbar">
+            <Scroll as="main" className="flex-1">
                 <section className="flex flex-col gap-8 pb-8">
                     <div className="flex w-full flex-col gap-[22px] px-4 pt-[17px] tablet:px-5 desktop:px-16 desktop:pt-0">
                         <SettingsProfileImage channelName={channel.name} />
@@ -82,7 +83,7 @@ export default function SettingsPage() {
                         />
                     </div>
                 </section>
-            </main>
+            </Scroll>
         </div>
     )
 }

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -60,7 +60,7 @@ export default function SettingsPage() {
                             <NotificationRow
                                 title="마케팅 이메일 수신 동의"
                                 description="이벤트 또는 혜택과 관련된 마케팅 이메일 수신을 받아요"
-                                checked
+                                defaultChecked
                             />
                             <NotificationRow
                                 title="일일 콘텐츠 추천 메일 수신"

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -69,6 +69,8 @@ interface ToggleProps {
 }
 
 function Toggle({ checked = false, label }: ToggleProps) {
+    const thumbPositionClass = checked ? 'left-[21.6px]' : 'left-[2.4px]'
+
     return (
         <button
             type="button"
@@ -77,7 +79,7 @@ function Toggle({ checked = false, label }: ToggleProps) {
             className={`relative h-6 w-[43.2px] shrink-0 rounded-3xl transition-colors ${checked ? 'bg-primary-60' : 'bg-bg-2'}`}
         >
             <span
-                className={`absolute top-[2.4px] size-[19.2px] rounded-full bg-gray-95 transition-transform ${checked ? 'translate-x-[21.6px]' : 'translate-x-[2.4px]'}`}
+                className={`absolute top-[2.4px] size-[19.2px] rounded-full bg-gray-95 transition-[left] ${thumbPositionClass}`}
             />
         </button>
     )
@@ -101,6 +103,27 @@ function NotificationRow({ title, description, checked = false }: NotificationRo
             <p className="truncate font-caption-12r text-text-secondary desktop:font-body-14r">
                 {description}
             </p>
+        </div>
+    )
+}
+
+function EmailNotificationSection() {
+    return (
+        <div className="flex w-full flex-col gap-2 px-4 tablet:px-5 desktop:px-16">
+            <p className="font-caption-12m text-text-secondary desktop:font-body-14m">
+                이메일 알림
+            </p>
+            <div className="flex w-full flex-col gap-4">
+                <NotificationRow
+                    title="마케팅 이메일 수신 동의"
+                    description="이벤트 또는 혜택과 관련된 마케팅 이메일 수신을 받아요"
+                    checked
+                />
+                <NotificationRow
+                    title="일일 콘텐츠 추천 메일 수신"
+                    description="프리미엄 요금제에서 제공되는 일일 콘텐츠를 추천 받아요"
+                />
+            </div>
         </div>
     )
 }
@@ -173,22 +196,7 @@ export default function SettingsPage() {
 
                     <SectionDivider />
 
-                    <div className="flex w-full flex-col gap-2 px-4 tablet:px-5 desktop:px-16">
-                        <p className="font-caption-12m text-text-secondary desktop:font-body-14m">
-                            이메일 알림
-                        </p>
-                        <div className="flex w-full flex-col gap-4">
-                            <NotificationRow
-                                title="마케팅 이메일 수신 동의"
-                                description="이벤트 또는 혜택과 관련된 마케팅 이메일 수신을 받아요"
-                                checked
-                            />
-                            <NotificationRow
-                                title="일일 콘텐츠 추천 메일 수신"
-                                description="프리미엄 요금제에서 제공되는 일일 콘텐츠를 추천 받아요"
-                            />
-                        </div>
-                    </div>
+                    <EmailNotificationSection />
 
                     <SectionDivider />
 

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import Scroll from '@/components/Scroll'
 import ActionRow from './_components/ActionRow'
 import EditableTextField from './_components/EditableTextField'
@@ -16,6 +17,11 @@ const channel = {
 }
 
 export default function SettingsPage() {
+    const [emailNotifications, setEmailNotifications] = useState({
+        dailyRecommendation: false,
+        marketing: true,
+    })
+
     return (
         <div className="flex h-full w-full flex-col bg-bg-0">
             <SettingHeader />
@@ -60,13 +66,20 @@ export default function SettingsPage() {
                         </p>
                         <div className="flex w-full flex-col gap-4">
                             <NotificationRow
+                                checked={emailNotifications.marketing}
                                 title="마케팅 이메일 수신 동의"
                                 description="이벤트 또는 혜택과 관련된 마케팅 이메일 수신을 받아요"
-                                defaultChecked
+                                onChange={(checked) => {
+                                    setEmailNotifications((current) => ({ ...current, marketing: checked }))
+                                }}
                             />
                             <NotificationRow
+                                checked={emailNotifications.dailyRecommendation}
                                 title="일일 콘텐츠 추천 메일 수신"
                                 description="프리미엄 요금제에서 제공되는 일일 콘텐츠를 추천 받아요"
+                                onChange={(checked) => {
+                                    setEmailNotifications((current) => ({ ...current, dailyRecommendation: checked }))
+                                }}
                             />
                         </div>
                     </div>

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -37,8 +37,6 @@ export default function SettingsPage() {
                                 placeholder="더욱 최적화된 분석 및 제안을 위해 채널 타겟층을 입력해주세요"
                                 fullWidth
                                 inputClassName="h-[88px] desktop:h-[100px]"
-                                activeInputClassName="h-[67px] desktop:h-[67px]"
-                                className="[&>div]:focus-within:h-[67px] desktop:[&>div]:focus-within:h-[67px]"
                                 labelClassName="desktop:font-body-14m"
                                 textareaClassName="desktop:font-body-16r"
                             />

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -1,6 +1,8 @@
+'use client'
+
 import Scroll from '@/components/Scroll'
-import TextField from '@/components/TextField'
 import ActionRow from './_components/ActionRow'
+import EditableTextField from './_components/EditableTextField'
 import NotificationRow from './_components/NotificationRow'
 import ProfileField from './_components/ProfileField'
 import SectionDivider from './_components/SectionDivider'
@@ -29,16 +31,18 @@ export default function SettingsPage() {
                         </div>
 
                         <div className="flex w-full flex-col gap-2">
-                            <TextField
+                            <EditableTextField
                                 label="채널 타겟층"
                                 maxLength={50}
                                 placeholder="더욱 최적화된 분석 및 제안을 위해 채널 타겟층을 입력해주세요"
                                 fullWidth
                                 inputClassName="h-[88px] desktop:h-[100px]"
+                                activeInputClassName="h-[67px] desktop:h-[67px]"
+                                className="[&>div]:focus-within:h-[67px] desktop:[&>div]:focus-within:h-[67px]"
                                 labelClassName="desktop:font-body-14m"
                                 textareaClassName="desktop:font-body-16r"
                             />
-                            <TextField
+                            <EditableTextField
                                 label="채널 컨셉"
                                 maxLength={150}
                                 placeholder="더욱 최적화된 분석 및 제안을 위해 채널 컨셉을 입력해주세요"

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import MenuIcon from '@/assets/icons/menu.svg'
+import ProfileImage from '@/components/ProfileImage'
 import { useLayoutStore } from '@/stores/layoutStore'
 
 const channel = {
@@ -50,14 +51,15 @@ function ProfileField({ label, value }: ProfileFieldProps) {
     )
 }
 
-function ProfileAvatar() {
+function SettingsProfileImage() {
+    const label = `${channel.name} 프로필 이미지`
+
     return (
-        <div
-            className="flex size-20 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary-40 text-[20px] font-semibold leading-none text-text-primary tablet:size-[120px] tablet:text-[28px] desktop:size-[193px] desktop:text-[44px]"
-            aria-label={`${channel.name} 프로필 이미지`}
-        >
-            LJ
-        </div>
+        <>
+            <ProfileImage size={80} aria-label={label} className="tablet:hidden" />
+            <ProfileImage size={120} aria-label={label} className="hidden tablet:block desktop:hidden" />
+            <ProfileImage size={193} aria-label={label} className="hidden desktop:block" />
+        </>
     )
 }
 
@@ -184,7 +186,7 @@ export default function SettingsPage() {
             <main className="flex-1 overflow-y-auto custom-scrollbar">
                 <section className="flex flex-col gap-8 pb-8">
                     <div className="flex w-full flex-col gap-[22px] px-4 pt-[17px] tablet:px-5 desktop:px-16 desktop:pt-0">
-                        <ProfileAvatar />
+                        <SettingsProfileImage />
 
                         <div className="flex w-full flex-col gap-2">
                             <ProfileField label="채널명" value={channel.name} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,8 +32,10 @@
     --breakpoint-mobile: 360px;
 
     /* 기본 컬러 칩 */
+    --color-black: #020202;
     --color-primary-5: #170305;
     --color-primary-10: #2d060a;
+    --color-primary-20: #5b0b13;
     --color-primary-30: #88111d;
     --color-primary-40: #b61627;
     --color-primary-50: #da1b2e;
@@ -43,8 +45,7 @@
     --color-primary-90: #f9d2d6;
     --color-primary-95: #fce8ea;
 
-    --color-gray-0: #141415;
-    --color-gray-5: #19191b;
+    --color-gray-5: #141415;
     --color-gray-10: #1e1e20;
     --color-gray-20: #252527;
     --color-gray-30: #37363a;
@@ -55,8 +56,12 @@
     --color-gray-80: #cbcace;
     --color-gray-90: #e5e5e6;
     --color-gray-95: #f2f2f3;
+    --color-white: #fcfcfd;
 
-    --color-red-error: #ff4d4f;
+    --color-red-error: #f50019;
+
+    /* 기존 class 호환 alias */
+    --color-gray-0: var(--color-gray-5);
 
     /* --- Semantic Tokens --- */
     /* Background */
@@ -64,6 +69,7 @@
     --color-bg-1: var(--color-gray-10);
     --color-bg-2: var(--color-gray-20);
     --color-bg-3: var(--color-gray-30);
+    --color-bg-divider: var(--color-black);
 
     /* Border */
     --color-border-default: var(--color-gray-20);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,6 @@
 import type { Metadata } from 'next'
-import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
 import { Providers } from '@/lib/providers'
-
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin'],
-})
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-})
 
 export const metadata: Metadata = {
   title: '채널링 - 유튜브 분석 서비스',
@@ -26,7 +15,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className="antialiased">
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/components/Line.tsx
+++ b/src/components/Line.tsx
@@ -5,7 +5,7 @@ interface LineProps {
 export default function Line({ variant }: LineProps) {
     const heightClass = variant === 'thin' ? 'h-[1px]' : variant === 'medium' ? 'h-2' : 'h-4';
 
-    const bgClass = variant === 'thick' ? 'bg-[#020202]' : 'bg-border-subtle';
+    const bgClass = variant === 'thick' ? 'bg-bg-divider' : 'bg-border-subtle';
 
     const layoutClass = variant === 'thick' ? 'w-full self-stretch' : 'w-[328px]';
 

--- a/src/components/Scroll.tsx
+++ b/src/components/Scroll.tsx
@@ -1,16 +1,25 @@
-import { HTMLAttributes, ReactNode } from 'react';
+import { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react';
 
-interface ScrollProps extends HTMLAttributes<HTMLDivElement> {
+interface ScrollProps<T extends ElementType = 'div'> {
+    as?: T;
     children: ReactNode;
+    className?: string;
 }
 
-export default function Scroll({ children, className = '', ...props }: ScrollProps) {
+export default function Scroll<T extends ElementType = 'div'>({
+    as,
+    children,
+    className = '',
+    ...props
+}: ScrollProps<T> & Omit<ComponentPropsWithoutRef<T>, keyof ScrollProps<T>>) {
+    const Component = as ?? 'div'
+
     return (
-        <div 
+        <Component
             className={`overflow-y-auto custom-scrollbar ${className}`} 
             {...props}
         >
             {children}
-        </div>
+        </Component>
     );
 }

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -51,7 +51,6 @@ export default function TextField({
   const isControlled = controlledValue !== undefined
   const value = isControlled ? controlledValue : internalValue
 
-  const [isFocused, setIsFocused] = useState(false)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const autoId = useId()
   const inputId = externalId ?? autoId
@@ -79,7 +78,7 @@ export default function TextField({
         className={[
           'relative flex flex-col w-full px-[16px] py-[12px] bg-bg-1 rounded-[20px]',
           heightVariant === 'large' ? 'h-[151px]' : 'h-[88px]', // variant에 따른 높이 분기
-          isActive || isFocused
+          isActive
             ? 'shadow-[inset_0_0_0_1px_var(--color-border-active)]'
               : isError
                 ? 'shadow-[inset_0_0_0_1px_var(--color-border-error)]'
@@ -139,14 +138,8 @@ export default function TextField({
             id={inputId}
             value={value}
             onChange={handleChange}
-            onFocus={(event) => {
-              setIsFocused(true)
-              externalOnFocus?.(event)
-            }}
-            onBlur={(event) => {
-              setIsFocused(false)
-              externalOnBlur?.(event)
-            }}
+            onFocus={externalOnFocus}
+            onBlur={externalOnBlur}
             aria-placeholder={placeholder}
             className={[
               'absolute inset-0 w-full h-full bg-transparent outline-none m-0 p-0 resize-none',

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -14,6 +14,10 @@ export interface TextFieldProps
   isError?: boolean
   errorMessage?: string
   className?: string
+  inputClassName?: string
+  labelClassName?: string
+  textareaClassName?: string
+  fullWidth?: boolean
   sizeVariant?: 'mobile' | 'tablet' | 'desktop'
   heightVariant?: 'small' | 'large' // 높이 크기 분기 (기본: small: 88px, large: 151px)
 }
@@ -29,6 +33,10 @@ export default function TextField({
   isError = false,
   errorMessage,
   className = '',
+  inputClassName = '',
+  labelClassName = '',
+  textareaClassName = '',
+  fullWidth = false,
   sizeVariant = 'mobile',
   heightVariant = 'small',
   id: externalId,
@@ -45,7 +53,6 @@ export default function TextField({
   const inputId = externalId ?? autoId
 
   const textLength = value.length
-  const isActive = isFocused || textLength > 0
   const showPlaceholder = textLength === 0
 
   function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
@@ -57,12 +64,12 @@ export default function TextField({
 
   const widthClass: Record<Required<TextFieldProps>['sizeVariant'], string> = {
     mobile: 'w-[328px]',
-    tablet: 'w-[328px]', // 향후 수정
-    desktop: 'w-[328px]', // 향후 수정
+    tablet: 'w-[328px]',
+    desktop: 'w-[328px]',
   }
 
   return (
-    <div className={`flex flex-col gap-[4px] ${widthClass[sizeVariant]} ${className}`}>
+    <div className={`flex flex-col gap-[4px] ${fullWidth ? 'w-full' : widthClass[sizeVariant]} ${className}`}>
       {/* 메인 Input 래퍼 */}
       <div
         className={[
@@ -70,10 +77,11 @@ export default function TextField({
           heightVariant === 'large' ? 'h-[151px]' : 'h-[88px]', // variant에 따른 높이 분기
           isFocused
             ? 'shadow-[inset_0_0_0_1px_var(--color-border-active)]'
-            : isError
-              ? 'shadow-[inset_0_0_0_1px_var(--color-border-error)]'
-              : '',
+              : isError
+                ? 'shadow-[inset_0_0_0_1px_var(--color-border-error)]'
+                : '',
           'transition-colors duration-150 cursor-text',
+          inputClassName,
         ].join(' ')}
         onClick={() => inputRef.current?.focus()}
       >
@@ -83,7 +91,7 @@ export default function TextField({
             {label ? (
               <label
                 htmlFor={inputId}
-                className="font-caption-12m text-text-secondary tracking-[-0.3px]"
+                className={`font-caption-12m text-text-secondary tracking-[-0.3px] ${labelClassName}`}
               >
                 {label}
               </label>
@@ -104,9 +112,19 @@ export default function TextField({
         <div className="relative flex-1 flex flex-col justify-start">
           {showPlaceholder && (
             <div className="absolute inset-0 flex flex-col justify-start pointer-events-none text-text-secondary">
-              <p className="font-body-14r tracking-[-0.35px]">{placeholder}</p>
+              <p
+                className={`font-body-14r tracking-[-0.35px] ${textareaClassName}`}
+                style={{ wordBreak: 'break-all', overflowWrap: 'anywhere' }}
+              >
+                {placeholder}
+              </p>
               {helperText && (
-                <p className="font-body-14r tracking-[-0.35px]">{helperText}</p>
+                <p
+                  className={`font-body-14r tracking-[-0.35px] ${textareaClassName}`}
+                  style={{ wordBreak: 'break-all', overflowWrap: 'anywhere' }}
+                >
+                  {helperText}
+                </p>
               )}
             </div>
           )}
@@ -125,6 +143,7 @@ export default function TextField({
               heightVariant === 'large' ? 'overflow-y-auto custom-scrollbar pr-[4px]' : 'overflow-hidden',
               'font-body-14r tracking-[-0.35px] text-text-primary caret-gray-90',
               showPlaceholder ? 'text-transparent' : '',
+              textareaClassName,
             ].join(' ')}
             {...rest}
           />

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -11,6 +11,7 @@ export interface TextFieldProps
   showCounter?: boolean // 카운터 표시 여부 (기본: true)
   placeholder?: string
   helperText?: string
+  isActive?: boolean
   isError?: boolean
   errorMessage?: string
   className?: string
@@ -30,6 +31,7 @@ export default function TextField({
   showCounter = true,
   placeholder,
   helperText,
+  isActive = false,
   isError = false,
   errorMessage,
   className = '',
@@ -40,6 +42,8 @@ export default function TextField({
   sizeVariant = 'mobile',
   heightVariant = 'small',
   id: externalId,
+  onFocus: externalOnFocus,
+  onBlur: externalOnBlur,
   ...rest
 }: TextFieldProps) {
   // 제어/비제어 호환
@@ -75,12 +79,12 @@ export default function TextField({
         className={[
           'relative flex flex-col w-full px-[16px] py-[12px] bg-bg-1 rounded-[20px]',
           heightVariant === 'large' ? 'h-[151px]' : 'h-[88px]', // variant에 따른 높이 분기
-          isFocused
+          isActive || isFocused
             ? 'shadow-[inset_0_0_0_1px_var(--color-border-active)]'
               : isError
                 ? 'shadow-[inset_0_0_0_1px_var(--color-border-error)]'
                 : '',
-          'transition-colors duration-150 cursor-text',
+          'transition-colors duration-150 cursor-text focus-within:shadow-[inset_0_0_0_1px_var(--color-border-active)]',
           inputClassName,
         ].join(' ')}
         onClick={() => inputRef.current?.focus()}
@@ -135,8 +139,14 @@ export default function TextField({
             id={inputId}
             value={value}
             onChange={handleChange}
-            onFocus={() => setIsFocused(true)}
-            onBlur={() => setIsFocused(false)}
+            onFocus={(event) => {
+              setIsFocused(true)
+              externalOnFocus?.(event)
+            }}
+            onBlur={(event) => {
+              setIsFocused(false)
+              externalOnBlur?.(event)
+            }}
             aria-placeholder={placeholder}
             className={[
               'absolute inset-0 w-full h-full bg-transparent outline-none m-0 p-0 resize-none',

--- a/src/lib/providers.tsx
+++ b/src/lib/providers.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { useState } from 'react'
 
 export function Providers({ children }: { children: React.ReactNode }) {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import type { StateCreator } from 'zustand'
 import type { User } from '@/types'
 
 interface AuthState {
@@ -10,20 +11,20 @@ interface AuthState {
     completeOnboarding: () => void
 }
 
-export const useAuthStore = create<AuthState>()(
-    persist(
-        (set) => ({
-            user: null,
-            isLoggedIn: false,
-            setUser: (user) => set({ user, isLoggedIn: true }),
-            clearUser: () => set({ user: null, isLoggedIn: false }),
-            completeOnboarding: () =>
-                set((state) => ({
-                    user: state.user ? { ...state.user, isOnboardingCompleted: true } : null,
-                })),
-        }),
-        {
-            name: 'auth-storage',
-        }
-    )
-)
+const createAuthState = persist<AuthState>(
+    (set) => ({
+        user: null,
+        isLoggedIn: false,
+        setUser: (user) => set({ user, isLoggedIn: true }),
+        clearUser: () => set({ user: null, isLoggedIn: false }),
+        completeOnboarding: () =>
+            set((state) => ({
+                user: state.user ? { ...state.user, isOnboardingCompleted: true } : null,
+            })),
+    }),
+    {
+        name: 'auth-storage',
+    }
+) as unknown as StateCreator<AuthState>
+
+export const useAuthStore = create<AuthState>()(createAuthState)


### PR DESCRIPTION
## 💡 Related Issue

- closed #000

## ✅ Summary

설정 페이지 UI를 구현하고, 텍스트필드 편집 상태 및 이메일 알림 토글 인터랙션을 적용했습니다.

## 📝 Description

- Figma 기반 설정 페이지 반응형 UI 구현
- 기존 공용 `ProfileImage`, `TextField`, `Scroll` 컴포넌트 활용 및 보완
- 텍스트필드 입력 시 `취소` / `저장` 버튼 노출 및 상태 처리
- 이메일 알림 토글 활성화 / 비활성화 동작 구현
- Figma 컬러 팔레트 기준으로 배경색, error color, divider token 수정
- 모바일, 태블릿, 데스크톱 화면 및 overflow 확인

### Screenshot

| Mobile | Tablet | Desktop |
| --- | --- | --- |
| 첨부 예정 | 첨부 예정 | 첨부 예정 |

## 💬 리뷰 요구 사항

- 설정 페이지의 반응형 레이아웃과 텍스트필드 편집 동작을 확인해주세요.