### PR TITLE
[FIX] 공용 레이아웃 및 아이디어 페이지 수정

### DIFF
--- a/src/app/(protected)/dashboard/insights/[id]/page.tsx
+++ b/src/app/(protected)/dashboard/insights/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from 'next/navigation'
 import Scroll from '@/components/Scroll'
+import PageContent from '@/components/layout/PageContent'
 import { dashboardInsights, getDashboardInsight } from '../../_data/insights'
 import InsightDetailContent from './_components/InsightDetailContent'
 import InsightDetailHeader from './_components/InsightDetailHeader'
@@ -21,10 +22,10 @@ export default async function InsightDetailPage({ params }: InsightDetailPagePro
     return (
         <div className="flex h-full w-full flex-col bg-bg-0">
             <Scroll as="main" className="flex-1">
-                <div className="flex w-full flex-col gap-4 px-5 pb-8 desktop:px-16 desktop:pb-16">
+                <PageContent className="flex flex-col gap-4 pb-8 desktop:pb-16">
                     <InsightDetailHeader />
                     <InsightDetailContent insight={insight} />
-                </div>
+                </PageContent>
             </Scroll>
         </div>
     )

--- a/src/app/(protected)/dashboard/page.tsx
+++ b/src/app/(protected)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import Scroll from '@/components/Scroll'
+import PageContent from '@/components/layout/PageContent'
 import DashboardHeader from './_components/DashboardHeader'
 import InsightCard from './_components/InsightCard'
 import MetricCardSmall from './_components/MetricCardSmall'
@@ -22,7 +23,7 @@ export default function DashboardPage() {
             <DashboardHeader />
 
             <Scroll as="main" className="flex-1">
-                <div className="mx-auto flex w-full flex-col gap-8 px-4 pb-8 pt-4 tablet:px-5 desktop:px-16 desktop:pb-16 desktop:pt-8">
+                <PageContent className="mx-auto flex flex-col gap-8 pb-8 pt-4 desktop:pb-16 desktop:pt-8">
                     <section className="flex w-full flex-col gap-2">
                         <p className="font-body-14r text-text-tertiary">
                             26년 2월 19일 (05:15) 기준
@@ -65,7 +66,7 @@ export default function DashboardPage() {
                         </div>
                     </section>
 
-                </div>
+                </PageContent>
             </Scroll>
             <Footer />
         </div>

--- a/src/app/(protected)/feedback/page.tsx
+++ b/src/app/(protected)/feedback/page.tsx
@@ -1,16 +1,18 @@
 'use client'
 
+import PageContent from '@/components/layout/PageContent'
+
 /**
  * 피드백 페이지 (/feedback)
  * - 사용자 의견 작성 및 전송
  */
 export default function FeedbackPage() {
     return (
-        <main className="p-6">
+        <PageContent as="main" className="py-6">
             <h1 className="text-2xl font-bold">피드백</h1>
             <p className="text-gray-500 mt-2">서비스 개선을 위한 의견을 보내주세요.</p>
 
             {/* TODO: 피드백 입력 폼 */}
-        </main>
+        </PageContent>
     )
 }

--- a/src/app/(protected)/ideas/_components/saved-idea.tsx
+++ b/src/app/(protected)/ideas/_components/saved-idea.tsx
@@ -46,7 +46,7 @@ export default function SavedIdea() {
     }
 
     return (
-        <div className="flex flex-col gap-2 justify-start w-full  px-4 desktop:px-8">
+        <div className="flex w-full flex-col justify-start gap-2 px-4 tablet:px-5 desktop:px-16">
             <h1 className="text-text-primary font-title-18sb">저장한 아이디어</h1>
             <div className="flex flex-col gap-4">
                 <SearchBar />

--- a/src/app/(protected)/ideas/_components/saved-idea.tsx
+++ b/src/app/(protected)/ideas/_components/saved-idea.tsx
@@ -3,6 +3,7 @@ import SavedIdeaCard from './saved-idea-card'
 import SearchBar from './search-bar'
 import IdeaDetailView from './idea-detail-view'
 import Dropdown from '@/assets/icons/dropdown.svg'
+import PageContent from '@/components/layout/PageContent'
 import DropdownOrder from './dropdown-order'
 
 export default function SavedIdea() {
@@ -46,7 +47,7 @@ export default function SavedIdea() {
     }
 
     return (
-        <div className="flex w-full flex-col justify-start gap-2 px-4 tablet:px-5 desktop:px-16">
+        <PageContent className="flex flex-col justify-start gap-2">
             <h1 className="text-text-primary font-title-18sb">저장한 아이디어</h1>
             <div className="flex flex-col gap-4">
                 <SearchBar />
@@ -76,6 +77,6 @@ export default function SavedIdea() {
                 </div>
                 <SavedIdeaCard onClick={() => setSelectedIdea(true)} />
             </div>
-        </div>
+        </PageContent>
     )
 }

--- a/src/app/(protected)/ideas/page.tsx
+++ b/src/app/(protected)/ideas/page.tsx
@@ -3,6 +3,7 @@
 import MenuIcon from '@/assets/icons/menu.svg'
 import Line from '@/components/Line'
 import Header from '@/components/layout/Header'
+import PageContent from '@/components/layout/PageContent'
 import Scroll from '@/components/Scroll'
 import { useLayoutStore } from '@/stores/layoutStore'
 import ContentIdeaGeneration from './_components/content-idea-generation'
@@ -35,11 +36,11 @@ export default function IdeasPage() {
 
             <Scroll as="main" className="flex-1">
                 <div className="flex flex-col gap-8 pb-16">
-                    <div className="flex w-full flex-col items-center gap-3.5 px-4 tablet:px-5 desktop:px-16">
+                    <PageContent className="flex flex-col items-center gap-3.5">
                         <TrendKeyword />
                         <Line variant="thin" />
                         <ContentIdeaGeneration />
-                    </div>
+                    </PageContent>
                     <Line variant="thick" />
                     <SavedIdea />
                 </div>

--- a/src/app/(protected)/ideas/page.tsx
+++ b/src/app/(protected)/ideas/page.tsx
@@ -35,7 +35,7 @@ export default function IdeasPage() {
 
             <Scroll as="main" className="flex-1">
                 <div className="flex flex-col gap-8 pb-16">
-                    <div className="flex w-full flex-col items-center gap-3.5 px-4 desktop:px-8">
+                    <div className="flex w-full flex-col items-center gap-3.5 px-4 tablet:px-5 desktop:px-16">
                         <TrendKeyword />
                         <Line variant="thin" />
                         <ContentIdeaGeneration />

--- a/src/app/(protected)/ideas/page.tsx
+++ b/src/app/(protected)/ideas/page.tsx
@@ -5,6 +5,7 @@ import ContentIdeaGeneration from './_components/content-idea-generation'
 import Line from '@/components/Line'
 import SavedIdea from './_components/saved-idea'
 import Header from '@/components/layout/Header'
+import Scroll from '@/components/Scroll'
 
 /**
  * 아이디어 페이지 (/ideas)
@@ -13,17 +14,20 @@ import Header from '@/components/layout/Header'
  */
 export default function IdeasPage() {
     return (
-        <main className="">
+        <div className="flex h-full w-full flex-col bg-bg-0">
             <Header title="트렌드 · 아이디어" />
-            <div className="flex flex-col gap-8 pb-16">
-                <div className="flex flex-col gap-3.5 items-center w-full px-4 desktop:px-8">
-                    <TrendKeyword />
-                    <Line variant="thin" />
-                    <ContentIdeaGeneration />
+
+            <Scroll as="main" className="flex-1">
+                <div className="flex flex-col gap-8 pb-16">
+                    <div className="flex w-full flex-col items-center gap-3.5 px-4 desktop:px-8">
+                        <TrendKeyword />
+                        <Line variant="thin" />
+                        <ContentIdeaGeneration />
+                    </div>
+                    <Line variant="thick" />
+                    <SavedIdea />
                 </div>
-                <Line variant="thick" />
-                <SavedIdea />
-            </div>
-        </main>
+            </Scroll>
+        </div>
     )
 }

--- a/src/app/(protected)/ideas/page.tsx
+++ b/src/app/(protected)/ideas/page.tsx
@@ -22,11 +22,12 @@ export default function IdeasPage() {
         <div className="flex h-full w-full flex-col bg-bg-0">
             <Header
                 title="트렌드 · 아이디어"
+                leadingClassName="desktop:hidden"
                 leading={
                     <button
                         type="button"
                         onClick={openSidebar}
-                        className="-ml-1 flex size-8 items-center justify-center text-icon-primary transition-colors hover:text-text-primary desktop:hidden"
+                        className="-ml-1 flex size-8 items-center justify-center text-icon-primary transition-colors hover:text-text-primary"
                         aria-label="메뉴 열기"
                     >
                         <MenuIcon />

--- a/src/app/(protected)/ideas/page.tsx
+++ b/src/app/(protected)/ideas/page.tsx
@@ -1,11 +1,13 @@
 'use client'
 
-import TrendKeyword from './_components/trend-keyword'
-import ContentIdeaGeneration from './_components/content-idea-generation'
+import MenuIcon from '@/assets/icons/menu.svg'
 import Line from '@/components/Line'
-import SavedIdea from './_components/saved-idea'
 import Header from '@/components/layout/Header'
 import Scroll from '@/components/Scroll'
+import { useLayoutStore } from '@/stores/layoutStore'
+import ContentIdeaGeneration from './_components/content-idea-generation'
+import SavedIdea from './_components/saved-idea'
+import TrendKeyword from './_components/trend-keyword'
 
 /**
  * 아이디어 페이지 (/ideas)
@@ -13,9 +15,23 @@ import Scroll from '@/components/Scroll'
  * - 아이디어 생성 도구
  */
 export default function IdeasPage() {
+    const openSidebar = useLayoutStore((state) => state.openSidebar)
+
     return (
         <div className="flex h-full w-full flex-col bg-bg-0">
-            <Header title="트렌드 · 아이디어" />
+            <Header
+                title="트렌드 · 아이디어"
+                leading={
+                    <button
+                        type="button"
+                        onClick={openSidebar}
+                        className="-ml-1 flex size-8 items-center justify-center text-icon-primary transition-colors hover:text-text-primary desktop:hidden"
+                        aria-label="메뉴 열기"
+                    >
+                        <MenuIcon />
+                    </button>
+                }
+            />
 
             <Scroll as="main" className="flex-1">
                 <div className="flex flex-col gap-8 pb-16">

--- a/src/app/(protected)/reports/[id]/page.tsx
+++ b/src/app/(protected)/reports/[id]/page.tsx
@@ -1,4 +1,5 @@
 import Header from '@/components/layout/Header'
+import PageContent from '@/components/layout/PageContent'
 import ReportTabs from '../_components/ReportTabs'
 
 interface ReportDetailPageProps {
@@ -15,9 +16,10 @@ export default async function ReportDetailPage({ params }: ReportDetailPageProps
     const { id } = await params
 
     return (
-        <main className="px-4 tablet:px-5 desktop:px-16 flex flex-col">
-            <Header title="상세 분석 리포트" />
-            <div className="pt-4 flex flex-col gap-4">
+        <div className="flex h-full w-full flex-col bg-bg-0">
+            <Header title="상세 분석 리포트" className="tablet:px-5 desktop:px-16" />
+
+            <PageContent as="main" className="flex flex-col gap-4 pt-4">
                 {/* 영상 정보 */}
                 <div className="flex gap-4 flex-col tablet:flex-row">
                     <div className="w-82 h-46 tablet:w-59.25 tablet:h-33.25 desktop:w-79 desktop:h-44.5 rounded-[20px] bg-bg-3"></div>
@@ -38,7 +40,7 @@ export default async function ReportDetailPage({ params }: ReportDetailPageProps
                 </div>
 
                 <ReportTabs />
-            </div>
-        </main>
+            </PageContent>
+        </div>
     )
 }

--- a/src/app/(protected)/reports/[id]/page.tsx
+++ b/src/app/(protected)/reports/[id]/page.tsx
@@ -17,7 +17,7 @@ export default async function ReportDetailPage({ params }: ReportDetailPageProps
 
     return (
         <div className="flex h-full w-full flex-col bg-bg-0">
-            <Header title="상세 분석 리포트" className="tablet:px-5 desktop:px-16" />
+            <Header title="상세 분석 리포트" />
 
             <PageContent as="main" className="flex flex-col gap-4 pt-4">
                 {/* 영상 정보 */}

--- a/src/app/(protected)/reports/page.tsx
+++ b/src/app/(protected)/reports/page.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import PageContent from '@/components/layout/PageContent'
+
 /**
  * 영상 리포트 목록 페이지 (/reports)
  * - 리포트 생성 섹션: 분석할 영상 URL 입력 및 리포트 생성 버튼
@@ -7,7 +9,7 @@
  */
 export default function ReportsPage() {
     return (
-        <main className="p-6">
+        <PageContent as="main" className="py-6">
             <h1 className="text-2xl font-bold">영상 리포트</h1>
 
             {/* 리포트 생성 섹션 */}
@@ -24,6 +26,6 @@ export default function ReportsPage() {
             </section>
 
             {/* TODO: 리포트 목록 섹션 */}
-        </main>
+        </PageContent>
     )
 }

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import Scroll from '@/components/Scroll'
+import PageContent from '@/components/layout/PageContent'
 import ActionRow from './_components/ActionRow'
 import EditableTextField from './_components/EditableTextField'
 import NotificationRow from './_components/NotificationRow'
@@ -28,7 +29,7 @@ export default function SettingsPage() {
 
             <Scroll as="main" className="flex-1">
                 <section className="flex flex-col gap-8 pb-8">
-                    <div className="flex w-full flex-col gap-[22px] px-4 pt-[17px] tablet:px-5 desktop:px-16 desktop:pt-0">
+                    <PageContent className="flex flex-col gap-[22px] pt-[17px] desktop:pt-0">
                         <SettingsProfileImage channelName={channel.name} />
 
                         <div className="flex w-full flex-col gap-2">
@@ -56,11 +57,11 @@ export default function SettingsPage() {
                                 textareaClassName="desktop:font-body-16r"
                             />
                         </div>
-                    </div>
+                    </PageContent>
 
                     <SectionDivider />
 
-                    <div className="flex w-full flex-col gap-2 px-4 tablet:px-5 desktop:px-16">
+                    <PageContent className="flex flex-col gap-2">
                         <p className="font-caption-12m text-text-secondary desktop:font-body-14m">
                             이메일 알림
                         </p>
@@ -82,11 +83,11 @@ export default function SettingsPage() {
                                 }}
                             />
                         </div>
-                    </div>
+                    </PageContent>
 
                     <SectionDivider />
 
-                    <div className="flex w-full flex-col gap-4 px-4 tablet:px-5 desktop:px-16">
+                    <PageContent className="flex flex-col gap-4">
                         <ActionRow
                             label={`${channel.loginId}로 로그인 되어 있습니다`}
                             buttonLabel="로그아웃"
@@ -96,7 +97,7 @@ export default function SettingsPage() {
                             buttonLabel="계정 삭제"
                             danger
                         />
-                    </div>
+                    </PageContent>
                 </section>
             </Scroll>
         </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from 'react'
 interface HeaderProps {
     className?: string
     leading?: ReactNode
+    leadingClassName?: string
     showDivider?: boolean
     title: string
     trailing?: ReactNode
@@ -29,14 +30,21 @@ interface HeaderProps {
  * />
  */
 
-export default function Header({ className = '', leading, showDivider = true, title, trailing }: HeaderProps) {
+export default function Header({
+    className = '',
+    leading,
+    leadingClassName = '',
+    showDivider = true,
+    title,
+    trailing,
+}: HeaderProps) {
     return (
         <header
             className={`flex min-h-14 w-full items-center justify-between bg-bg-0 px-4 py-3 tablet:px-5 desktop:px-16 ${showDivider ? 'border-b border-border-default' : ''} ${className}`}
         >
             <div className="flex items-center gap-2 desktop:gap-8">
                 {leading && (
-                    <div className="flex items-center shrink-0">
+                    <div className={`flex shrink-0 items-center ${leadingClassName}`}>
                         {leading}
                     </div>
                 )}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -32,7 +32,7 @@ interface HeaderProps {
 export default function Header({ className = '', leading, showDivider = true, title, trailing }: HeaderProps) {
     return (
         <header
-            className={`flex min-h-14 w-full items-center justify-between bg-bg-0 px-4 py-3 ${showDivider ? 'border-b border-border-default' : ''} ${className}`}
+            className={`flex min-h-14 w-full items-center justify-between bg-bg-0 px-4 py-3 tablet:px-5 desktop:px-16 ${showDivider ? 'border-b border-border-default' : ''} ${className}`}
         >
             <div className="flex items-center gap-2 desktop:gap-8">
                 {leading && (

--- a/src/components/layout/PageContent.tsx
+++ b/src/components/layout/PageContent.tsx
@@ -1,0 +1,25 @@
+import { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react'
+
+interface PageContentProps<T extends ElementType = 'div'> {
+    as?: T
+    children: ReactNode
+    className?: string
+}
+
+export default function PageContent<T extends ElementType = 'div'>({
+    as,
+    children,
+    className = '',
+    ...props
+}: PageContentProps<T> & Omit<ComponentPropsWithoutRef<T>, keyof PageContentProps<T>>) {
+    const Component = as ?? 'div'
+
+    return (
+        <Component
+            className={`w-full px-4 tablet:px-5 desktop:px-16 ${className}`}
+            {...props}
+        >
+            {children}
+        </Component>
+    )
+}


### PR DESCRIPTION
## 💡 Related Issue

- 관련 이슈 없음

## ✅ Summary

ideas 페이지의 스크롤/헤더/반응형 패딩 문제를 수정하고, 공통 콘텐츠 및 헤더 패딩 기준을 정리했습니다.

## 📝 Description

- ideas 페이지에서 본문만 스크롤되도록 `Scroll` 구조를 적용했습니다.
- 모바일/태블릿에서 사이드바 드로어 버튼이 보이도록 헤더 leading을 추가했습니다.
- 데스크탑에서는 ideas 헤더의 leading 영역이 남지 않도록 처리했습니다.
- 공통 콘텐츠 패딩을 `PageContent`로 분리했습니다.
- 공통 `Header`에도 동일한 좌우 패딩 기준을 적용했습니다.
- 기준값:
  - mobile 360: 16px
  - tablet 768: 20px
  - desktop 1440: 64px
- 페이지별 중복 패딩 적용 가능성을 줄이도록 기존 직접 패딩을 정리했습니다.

## 💬 리뷰 요구 사항

- ideas 페이지의 360 / 768 / 1440 반응형 패딩과 헤더 정렬을 중점적으로 확인 부탁드립니다.