### PR TITLE
[FIX] 공통 리포트 UI 및 레이아웃 수정

### DIFF
--- a/src/app/(protected)/dashboard/_components/DashboardHeader.tsx
+++ b/src/app/(protected)/dashboard/_components/DashboardHeader.tsx
@@ -11,8 +11,6 @@ export default function DashboardHeader() {
         <div className="desktop:hidden">
             <Header
                 title="대시보드"
-                showDivider={false}
-                className="tablet:min-h-16 tablet:px-5 tablet:py-4"
                 leading={
                     <button
                         type="button"

--- a/src/app/(protected)/ideas/page.tsx
+++ b/src/app/(protected)/ideas/page.tsx
@@ -19,7 +19,7 @@ export default function IdeasPage() {
     const openSidebar = useLayoutStore((state) => state.openSidebar)
 
     return (
-        <div className="flex h-full w-full flex-col bg-bg-0">
+        <div className="flex h-full w-full flex-col bg-bg-0 desktop:pt-3">
             <Scroll as="main" className="flex-1">
                 <Header
                     title="트렌드 · 아이디어"

--- a/src/app/(protected)/ideas/page.tsx
+++ b/src/app/(protected)/ideas/page.tsx
@@ -19,25 +19,22 @@ export default function IdeasPage() {
     const openSidebar = useLayoutStore((state) => state.openSidebar)
 
     return (
-        <div className="flex h-full w-full flex-col bg-bg-0 desktop:pt-3">
+        <div className="flex h-full w-full flex-col bg-bg-0">
             <Scroll as="main" className="flex-1">
-                <PageContent>
-                    <Header
-                        title="트렌드 · 아이디어"
-                        leadingClassName="desktop:hidden"
-                        showDivider={false}
-                        leading={
-                            <button
-                                type="button"
-                                onClick={openSidebar}
-                                className="-ml-1 flex size-8 items-center justify-center text-icon-primary transition-colors hover:text-text-primary"
-                                aria-label="메뉴 열기"
-                            >
-                                <MenuIcon />
-                            </button>
-                        }
-                    />
-                </PageContent>
+                <Header
+                    title="트렌드 · 아이디어"
+                    leadingClassName="desktop:hidden"
+                    leading={
+                        <button
+                            type="button"
+                            onClick={openSidebar}
+                            className="-ml-1 flex size-8 items-center justify-center text-icon-primary transition-colors hover:text-text-primary"
+                            aria-label="메뉴 열기"
+                        >
+                            <MenuIcon />
+                        </button>
+                    }
+                />
                 <div className="flex flex-col gap-8 pb-16">
                     <PageContent className="flex flex-col items-center gap-3.5">
                         <TrendKeyword />

--- a/src/app/(protected)/reports/page.tsx
+++ b/src/app/(protected)/reports/page.tsx
@@ -14,7 +14,7 @@ import Scroll from '@/components/Scroll'
  */
 export default function ReportsPage() {
     return (
-        <div className="flex h-full w-full flex-col bg-bg-0">
+        <div className="flex h-full w-full flex-col bg-bg-0 desktop:pt-3">
             <Scroll as="main" className="flex-1">
                 <Header title="영상 리포트" />
                 <PageContent className="flex flex-col gap-4 pb-6 pt-2">

--- a/src/app/(protected)/reports/page.tsx
+++ b/src/app/(protected)/reports/page.tsx
@@ -16,13 +16,11 @@ export default function ReportsPage() {
     return (
         <div className="flex h-full w-full flex-col bg-bg-0">
             <Scroll as="main" className="flex-1">
-                <PageContent className="py-6">
-                    <Header showDivider={false} title="영상 리포트" />
-                    <div className="flex flex-col gap-4 pt-2">
-                        <MyVideoList />
-                        <Line variant="thick" />
-                        <ReportList />
-                    </div>
+                <Header title="영상 리포트" />
+                <PageContent className="flex flex-col gap-4 pb-6 pt-2">
+                    <MyVideoList />
+                    <Line variant="thick" />
+                    <ReportList />
                 </PageContent>
             </Scroll>
         </div>

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -27,7 +27,7 @@ export default function SettingsPage() {
     })
 
     return (
-        <div className="flex h-full w-full flex-col bg-bg-0">
+        <div className="flex h-full w-full flex-col bg-bg-0 desktop:pt-3">
             <Scroll as="main" className="flex-1">
                 <Header
                     title="설정"

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -27,25 +27,22 @@ export default function SettingsPage() {
     })
 
     return (
-        <div className="flex h-full w-full flex-col bg-bg-0 desktop:pt-3">
+        <div className="flex h-full w-full flex-col bg-bg-0">
             <Scroll as="main" className="flex-1">
-                <PageContent>
-                    <Header
-                        title="설정"
-                        leadingClassName="desktop:hidden"
-                        showDivider={false}
-                        leading={
-                            <button
-                                type="button"
-                                onClick={openSidebar}
-                                className="-ml-1 flex size-8 items-center justify-center text-icon-primary transition-colors hover:text-text-primary"
-                                aria-label="메뉴 열기"
-                            >
-                                <MenuIcon />
-                            </button>
-                        }
-                    />
-                </PageContent>
+                <Header
+                    title="설정"
+                    leadingClassName="desktop:hidden"
+                    leading={
+                        <button
+                            type="button"
+                            onClick={openSidebar}
+                            className="-ml-1 flex size-8 items-center justify-center text-icon-primary transition-colors hover:text-text-primary"
+                            aria-label="메뉴 열기"
+                        >
+                            <MenuIcon />
+                        </button>
+                    }
+                />
                 <section className="flex flex-col gap-8 pb-8">
                     <PageContent className="flex flex-col gap-[22px] pt-[17px] desktop:pt-0">
                         <SettingsProfileImage channelName={channel.name} />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -39,7 +39,7 @@ export default function Header({
 }: HeaderProps) {
     return (
         <header
-            className={`flex min-h-14 w-full min-w-[360px] items-center justify-between bg-bg-0 px-4 py-3 tablet:min-h-16 tablet:min-w-[768px] tablet:px-5 tablet:py-4 desktop:mx-auto desktop:min-h-0 desktop:w-[1240px] desktop:px-16 desktop:py-5 ${className}`}
+            className={`flex min-h-14 w-full min-w-[360px] items-center justify-between bg-bg-0 px-4 py-3 tablet:min-h-16 tablet:min-w-[768px] tablet:px-5 tablet:py-4 desktop:min-h-0 desktop:px-16 desktop:py-5 ${className}`}
         >
             <div className="flex items-center gap-2">
                 {leading && <div className={`flex shrink-0 items-center ${leadingClassName}`}>{leading}</div>}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,7 +6,6 @@ interface HeaderProps {
     className?: string
     leading?: ReactNode
     leadingClassName?: string
-    showDivider?: boolean
     title: string
     trailing?: ReactNode
 }
@@ -14,8 +13,9 @@ interface HeaderProps {
 /**
  * 공통 Header 컴포넌트
  *
- * - 모든 보호된 페이지(protected)에서 공통으로 사용
+ * - 화면 상단 공통 header로 사용
  * - 구조: [leading] [title] ——————— [trailing]
+ * - spacing은 Figma header design system 기준을 따른다.
  *
  * @example 1
  * // 기본 (타이틀만)
@@ -34,15 +34,14 @@ export default function Header({
     className = '',
     leading,
     leadingClassName = '',
-    showDivider = true,
     title,
     trailing,
 }: HeaderProps) {
     return (
         <header
-            className={`flex min-h-14 w-full items-center justify-between bg-bg-0 py-3 ${showDivider ? 'border-b border-border-default' : ''} ${className}`}
+            className={`flex min-h-14 w-full min-w-[360px] items-center justify-between bg-bg-0 px-4 py-3 tablet:min-h-16 tablet:min-w-[768px] tablet:px-5 tablet:py-4 desktop:mx-auto desktop:min-h-0 desktop:w-[1240px] desktop:px-16 desktop:py-5 ${className}`}
         >
-            <div className="flex items-center gap-2 desktop:gap-8">
+            <div className="flex items-center gap-2">
                 {leading && <div className={`flex shrink-0 items-center ${leadingClassName}`}>{leading}</div>}
                 <span className="font-title-18sb text-text-primary whitespace-nowrap">{title}</span>
             </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -160,7 +160,7 @@ export default function Sidebar({ isOpen = true, onClose }: SidebarProps) {
                         onNavigate={onClose}
                     />
                     <div
-                        className={`group/profile relative flex w-full flex-col overflow-hidden rounded-lg p-2 transition-[max-height,gap,background-color] duration-300 hover:bg-bg-2 ${pathname === '/settings' ? 'bg-bg-2' : 'bg-transparent'} ${isDesktopCollapsed ? 'desktop:max-h-10 desktop:gap-0' : 'max-h-[109px] gap-2'}`}
+                        className={`group/profile relative flex w-full flex-col gap-2 overflow-hidden rounded-lg p-2 transition-[max-height,background-color] duration-300 hover:bg-bg-2 ${pathname === '/settings' ? 'bg-bg-2' : 'bg-transparent'} ${isDesktopCollapsed ? 'desktop:max-h-10' : 'max-h-[109px]'}`}
                     >
                         <Link
                             href="/settings"


### PR DESCRIPTION
## 💡 Related Issue

- 관련 이슈 없음

## ✅ Summary

공통 페이지 레이아웃과 리포트 화면의 UI 스타일을 정리했습니다. 아이디어/설정 페이지 헤더 패딩 누락을 수정하고, 드롭다운 옵션 텍스트 크기와 리포트 페이지 스크롤/텍스트 스타일을 보정했습니다.

## 📝 Description

- `/ideas`, `/settings` 페이지의 `Header`를 `PageContent`로 감싸 공용 좌우 패딩이 적용되도록 수정했습니다.
- `DropdownOrder`의 열린 옵션 버튼 텍스트를 `font-body-14m` 기준으로 맞추고, desktop에서도 14px로 유지되도록 오버라이드했습니다.
- `/reports` 페이지를 `Scroll` 컨테이너 구조로 변경해 콘텐츠 영역 내부에서만 스크롤되도록 수정했습니다.
- 리포트 페이지의 일부 제목/설명/칩 텍스트 크기를 디자인 기준에 맞게 조정했습니다.

```tsx
<div className="flex h-full w-full flex-col bg-bg-0">
    <Scroll as="main" className="flex-1">
        <PageContent className="py-6">
            ...
        </PageContent>
    </Scroll>
</div>
```

## 💬 리뷰 요구 사항

- desktop에서 /reports 스크롤 시 sidebar가 함께 올라가지 않는지 확인 부탁드립니다.
- /ideas, /settings 헤더 좌우 패딩이 다른 페이지와 동일하게 적용되는지 확인 부탁드립니다.