### PR TITLE
[DEV] 설정 페이지 요금제 관리 섹터 추가

### DIFF
--- a/src/app/(protected)/settings/_components/PlanManagementSection.tsx
+++ b/src/app/(protected)/settings/_components/PlanManagementSection.tsx
@@ -15,13 +15,17 @@ const usage = [
 ]
 
 function SectionLine() {
-    return <div className="h-px w-full bg-border-default" />
+    return (
+        <PageContent>
+            <div className="h-px w-full bg-border-default" />
+        </PageContent>
+    )
 }
 
 export default function PlanManagementSection() {
     return (
-        <PageContent className="flex flex-col gap-4">
-            <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-4">
+            <PageContent className="flex flex-col gap-2">
                 <p className="font-caption-12m text-text-secondary">플랜 관리</p>
                 <div className="flex flex-col gap-1">
                     <div className="flex items-center justify-between gap-4">
@@ -37,48 +41,46 @@ export default function PlanManagementSection() {
                         2026년 7월 2일에 자동으로 갱신됩니다
                     </p>
                 </div>
-            </div>
+            </PageContent>
 
             <SectionLine />
 
-            <div className="flex flex-col gap-2">
+            <PageContent className="flex flex-col gap-2">
                 <p className="font-caption-12m text-text-secondary">사용량</p>
-                <div className="flex flex-col">
-                    {usage.map((item) => (
-                        <div key={item.label} className="flex items-center justify-between gap-4 font-body-16sb">
-                            <span className="truncate text-text-primary">{item.label}</span>
-                            <span className="shrink-0">
-                                <span className="font-body-16m text-text-brand">{item.current}</span>
-                                <span className="font-body-16r text-text-secondary">/{item.limit}</span>
-                            </span>
-                        </div>
-                    ))}
-                </div>
-            </div>
+                {usage.map((item) => (
+                    <div key={item.label} className="flex items-center justify-between gap-4 font-body-16sb">
+                        <span className="truncate text-text-primary">{item.label}</span>
+                        <span className="shrink-0">
+                            <span className="font-body-16m text-text-brand">{item.current}</span>
+                            <span className="font-body-16r text-text-secondary">/{item.limit}</span>
+                        </span>
+                    </div>
+                ))}
+            </PageContent>
 
             <SectionLine />
 
-            <div className="flex flex-col gap-2 text-text-secondary">
+            <PageContent className="flex flex-col gap-2 text-text-secondary">
                 <p className="font-caption-12m">청구 내역</p>
                 <div className="flex flex-col gap-1 font-body-16r">
                     {billingHistory.map((billing) => (
-                        <div key={billing.date} className="grid grid-cols-[1fr_auto_auto] items-start gap-4">
-                            <span>{billing.date}</span>
-                            <span>{billing.amount}</span>
+                        <div key={billing.date} className="flex items-start justify-between">
+                            <span className="w-[107px] shrink-0 desktop:w-[138px]">{billing.date}</span>
+                            <span className="shrink-0 whitespace-nowrap">{billing.amount}</span>
                             <button
                                 type="button"
-                                className="font-body-14r underline underline-offset-2 transition-colors hover:text-text-primary"
+                                className="shrink-0 whitespace-nowrap font-body-14r underline underline-offset-2 transition-colors hover:text-text-primary"
                             >
                                 보기
                             </button>
                         </div>
                     ))}
                 </div>
-            </div>
+            </PageContent>
 
             <SectionLine />
 
-            <div className="flex flex-col gap-1">
+            <PageContent className="flex flex-col gap-1">
                 <div className="flex items-center justify-between gap-4">
                     <h2 className="font-body-16sb text-text-primary">플랜 취소</h2>
                     <button
@@ -91,7 +93,7 @@ export default function PlanManagementSection() {
                 <p className="truncate font-caption-12r text-text-secondary">
                     취소 후에도 만료일까지 이용 가능합니다
                 </p>
-            </div>
-        </PageContent>
+            </PageContent>
+        </div>
     )
 }

--- a/src/app/(protected)/settings/_components/PlanManagementSection.tsx
+++ b/src/app/(protected)/settings/_components/PlanManagementSection.tsx
@@ -1,0 +1,97 @@
+import Link from 'next/link'
+import PageContent from '@/components/layout/PageContent'
+
+const billingHistory = [
+    { date: '2026년 2월 2일', amount: '9,900원' },
+    { date: '2026년 3월 2일', amount: '9,900원' },
+    { date: '2026년 4월 2일', amount: '9,900원' },
+    { date: '2026년 5월 2일', amount: '9,900원' },
+    { date: '2026년 6월 2일', amount: '9,900원' },
+]
+
+const usage = [
+    { label: '리포트 생성 횟수', current: 5, limit: 10 },
+    { label: '아이디어 생성 횟수', current: 20, limit: 30 },
+]
+
+function SectionLine() {
+    return <div className="h-px w-full bg-border-default" />
+}
+
+export default function PlanManagementSection() {
+    return (
+        <PageContent className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+                <p className="font-caption-12m text-text-secondary">플랜 관리</p>
+                <div className="flex flex-col gap-1">
+                    <div className="flex items-center justify-between gap-4">
+                        <h2 className="font-body-16sb text-text-primary">Pro 플랜</h2>
+                        <Link
+                            href="/pricing"
+                            className="shrink-0 rounded-[20px] bg-primary-60 px-3 py-1.5 font-body-14m text-text-primary transition-colors hover:bg-primary-70"
+                        >
+                            업그레이드
+                        </Link>
+                    </div>
+                    <p className="truncate font-caption-12r text-text-secondary">
+                        2026년 7월 2일에 자동으로 갱신됩니다
+                    </p>
+                </div>
+            </div>
+
+            <SectionLine />
+
+            <div className="flex flex-col gap-2">
+                <p className="font-caption-12m text-text-secondary">사용량</p>
+                <div className="flex flex-col">
+                    {usage.map((item) => (
+                        <div key={item.label} className="flex items-center justify-between gap-4 font-body-16sb">
+                            <span className="truncate text-text-primary">{item.label}</span>
+                            <span className="shrink-0">
+                                <span className="font-body-16m text-text-brand">{item.current}</span>
+                                <span className="font-body-16r text-text-secondary">/{item.limit}</span>
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            <SectionLine />
+
+            <div className="flex flex-col gap-2 text-text-secondary">
+                <p className="font-caption-12m">청구 내역</p>
+                <div className="flex flex-col gap-1 font-body-16r">
+                    {billingHistory.map((billing) => (
+                        <div key={billing.date} className="grid grid-cols-[1fr_auto_auto] items-start gap-4">
+                            <span>{billing.date}</span>
+                            <span>{billing.amount}</span>
+                            <button
+                                type="button"
+                                className="font-body-14r underline underline-offset-2 transition-colors hover:text-text-primary"
+                            >
+                                보기
+                            </button>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            <SectionLine />
+
+            <div className="flex flex-col gap-1">
+                <div className="flex items-center justify-between gap-4">
+                    <h2 className="font-body-16sb text-text-primary">플랜 취소</h2>
+                    <button
+                        type="button"
+                        className="shrink-0 rounded-[20px] bg-bg-1 px-3 py-1.5 font-body-14m text-text-primary transition-colors hover:bg-bg-2"
+                    >
+                        취소
+                    </button>
+                </div>
+                <p className="truncate font-caption-12r text-text-secondary">
+                    취소 후에도 만료일까지 이용 가능합니다
+                </p>
+            </div>
+        </PageContent>
+    )
+}

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -9,6 +9,7 @@ import { useLayoutStore } from '@/stores/layoutStore'
 import ActionRow from './_components/ActionRow'
 import EditableTextField from './_components/EditableTextField'
 import NotificationRow from './_components/NotificationRow'
+import PlanManagementSection from './_components/PlanManagementSection'
 import ProfileField from './_components/ProfileField'
 import SectionDivider from './_components/SectionDivider'
 import SettingsProfileImage from './_components/SettingsProfileImage'
@@ -72,6 +73,10 @@ export default function SettingsPage() {
                             />
                         </div>
                     </PageContent>
+
+                    <SectionDivider />
+
+                    <PlanManagementSection />
 
                     <SectionDivider />
 


### PR DESCRIPTION
## 💡 Related Issue

- 관련 이슈: #000

## ✅ Summary

설정 페이지에 현재 플랜, 사용량, 청구 내역 및 플랜 취소 정보를 확인할 수 있는 요금제 관리 섹터를 추가했습니다.

## 📝 Description

- 설정 페이지의 프로필 영역과 이메일 알림 영역 사이에 요금제 관리 섹터를 추가했습니다.
- 현재 이용 중인 Pro 플랜과 자동 갱신 예정일을 표시했습니다.
- 업그레이드 버튼을 기존 `/pricing` 페이지와 연결했습니다.
- 리포트 및 아이디어 생성 사용량을 표시했습니다.
- 최근 청구 일자와 금액, 상세 내역 보기 버튼을 추가했습니다.
- 플랜 취소 안내와 취소 버튼을 추가했습니다.
- Figma 디자인을 기준으로 모바일, 태블릿, 데스크탑의 패딩과 요소 간격을 반영했습니다.
- 청구 내역의 날짜, 금액, 보기 버튼을 Figma와 동일한 `justify-between` 방식으로 정렬했습니다.
- 360px, 768px, 1440px 화면에서 반응형 레이아웃과 수평 overflow 여부를 확인했습니다.

## 💬 리뷰 요구 사항

- 사용량 항목 사이의 8px 간격이 Figma 디자인과 일치하는지 확인 부탁드립니다.
- 청구 내역의 날짜, 금액, 보기 버튼 정렬이 각 화면 크기에서 자연스러운지 확인 부탁드립니다.
- 업그레이드 버튼이 `/pricing`으로 이동하는 흐름이 적절한지 확인 부탁드립니다.